### PR TITLE
fix: sign-out link

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,7 @@ enum Selectors {
   REPORT_START_MONTH_INPUT = '#report-month-start',
   REPORT_START_YEAR_INPUT = '#report-year-start',
   REPORT_TYPE_INPUT = '#report-type',
-  SIGN_OUT_LINK = 'a[href*=sign-out]',
+  SIGN_OUT_LINK = 'a[href*=nav_signout]',
   SKIP_ACCOUNT_FIXUP_LINK = 'a[id*=skip]',
   SUBMIT_INPUT = 'input[type=submit]',
 }


### PR DESCRIPTION
The sign-out link must of been changed recently. 

![Screen Shot 2021-08-15 at 12 42 39 PM](https://user-images.githubusercontent.com/987706/129490519-b35e96d0-2562-4529-9fa4-0ca42c365f9f.png)


The update will fix this error:
```
/node_modules/amazon-order-reports-api/lib/index.js:198
            throw new Error(message ?? `Assertion failed! No element matching selector: ${selector}`);
                  ^

Error: No sign-out link detected, failed to sign in?
    at AmazonOrderReportsApi._assert (/node_modules/amazon-order-reports-api/lib/index.js:198:19)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async AmazonOrderReportsApi._handleLogin (/node_modules/amazon-order-reports-api/lib/index.js:331:9)
    at async AmazonOrderReportsApi._navigate (/node_modules/amazon-order-reports-api/lib/index.js:360:9)
    at async AmazonOrderReportsApi._getReport (/node_modules/amazon-order-reports-api/lib/index.js:265:9)
    at async AmazonOrderReportsApi.getItems (/node_modules/amazon-order-reports-api/lib/index.js:124:9)
...
```
