### PR TITLE
fix: increase navigation timeout to 90 from 30

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,9 @@ const DOWNLOAD_DIR_PREFIX = 'amzscr';
 const LOGIN_STEP_DELAY = 1000;
 const LOGIN_TYPING_DELAY = 200;
 
+// 90 second timeout
+const PAGE_TIMEOUT = 90000;
+
 puppeteer.use(StealthPlugin());
 
 interface ReportItem {
@@ -418,7 +421,7 @@ export class AmazonOrderReportsApi {
         });
       }),
       page.click(Selectors.REPORT_CONFIRM_LINK),
-      page.waitForResponse((r) => r.url().includes(Urls.DOWNLOAD_REPORT)),
+      page.waitForResponse((r) => r.url().includes(Urls.DOWNLOAD_REPORT), { timeout: PAGE_TIMEOUT }),
     ]);
 
     return downloadPath;
@@ -604,7 +607,7 @@ export class AmazonOrderReportsApi {
     }).toString();
 
     this.#logger.debug(`Navigating to ${url}`);
-    const response = await page.goto(url);
+    const response = await page.goto(url, { timeout: PAGE_TIMEOUT });
     if (!response?.ok()) {
       throw new Error(`Failed request while loading ${path}`);
     }


### PR DESCRIPTION
Fix occasional error by extending timeout from 30 to 90 seconds, especially when dealing with larger reports:
```
/node_modules/puppeteer/lib/cjs/puppeteer/common/helper.js:120
            rejectCallback(new Errors_js_1.TimeoutError('Timeout exceeded while waiting for event'));
                           ^

TimeoutError: Timeout exceeded while waiting for event
    at Timeout.<anonymous> (/node_modules/puppeteer/lib/cjs/puppeteer/common/helper.js:120:28)
    at listOnTimeout (node:internal/timers:557:17)
    at processTimers (node:internal/timers:500:7)
```